### PR TITLE
Bug Fix: Api docs are missing shift params for admin/jobs POST

### DIFF
--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -82,9 +82,26 @@ paths:
                         type: string
                       example:
                         - en
+                    shifts:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          start_datetime:
+                            type: string
+                            format: date_time
+                            example: "2025-04-10T09:00:00Z"
+                          end_datetime:
+                            type: string
+                            format: date_time
+                            example: "2025-04-10T17:00:00Z"
+                        required:
+                          - start_datetime
+                          - end_datetime
                   required:
                     - title
                     - hourly_salary
+                    - shifts
               required:
                 - job
   "/api/v1/admin/jobs/{id}":


### PR DESCRIPTION
### **PR Overview**

#### **Summary**

Fixing Minor bug where shifts params were missing from api docs. Now fixed to make this easier to test in api demo.

#### **Changes Introduced**

- [x] Shift params to api docs on POST admin/jobs so we can test in the UI

#### **Testing & Validation**

- [x]  Expand RSwag test
